### PR TITLE
Update ABI list

### DIFF
--- a/compiler-rt/lib/dfsan/done_abilist.txt
+++ b/compiler-rt/lib/dfsan/done_abilist.txt
@@ -35,7 +35,11 @@ fun:__polytracker_union=discard
 fun:__polytracker_log_union=uninstrumented
 fun:__polytracker_log_union=discard
 fun:__polytracker_union_table=uninstrumented
-fun:__polytracker_union_table=discard
+fun:__polytracker_union_table=discard 
+fun:__polytracker_start=uninstrumented
+fun:__polytracker_start=discard
+fun:__polytracker_size=uninstrumented
+fun:__polytracker_size=discard
 
 fun:__dfsan_update_label_count=uninstrumented
 fun:__dfsan_update_label_count=discard


### PR DESCRIPTION
This adds some new functions to the ignore list. 

We add polytracker_start at the beginning of main now, and polytracker_size is related to testing our handling of setjmp/longjmp/exceptions etc. 